### PR TITLE
added babel transform and code to use es6 modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,14 +2,15 @@ module.exports = function(grunt) {
   'use strict';
   require('load-grunt-tasks')(grunt);
 
-  var appDir = 'C:/code/arcgis-web-appbuilder-1.3/server/apps/3';
+  var appDir = 'C:/code/arcgis-web-appbuilder-1.3/server/apps/8';
   var stemappDir = 'C:/code/arcgis-web-appbuilder-1.3/client/stemapp';
   grunt.initConfig({
     babel: {
       options: {
         sourceMap: true,
-        presets: ['es2015-without-strict', 'stage-0'] // blacklisting 'strict' until dojo2 fixes class declarations. see http://dojo-toolkit.33424.n3.nabble.com/A-line-to-use-instead-of-quot-this-inherited-arguments-quot-in-strict-mode-td3999709.html
-        // plugins: ['transform-es2015-modules-amd']
+        // blacklisting 'strict' until dojo2 fixes class declarations. see http://dojo-toolkit.33424.n3.nabble.com/A-line-to-use-instead-of-quot-this-inherited-arguments-quot-in-strict-mode-td3999709.html
+        presets: ['es2015-without-strict', 'stage-0'],
+        plugins: ['transform-es2015-modules-simple-amd']
       },
       dev: {
         files: [{

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "author": "Gavin Rehkemper",
   "license": "ISC",
   "devDependencies": {
+    "babel-plugin-transform-es2015-modules-simple-amd": "^0.1.0",
     "babel-preset-es2015-without-strict": "0.0.2",
     "babel-preset-stage-0": "^6.3.13",
+    "babel-template": "^6.5.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
     "grunt-contrib-clean": "^1.0.0",

--- a/widgets/MyWidget/Widget.js
+++ b/widgets/MyWidget/Widget.js
@@ -1,9 +1,9 @@
-define([
-    'dojo/_base/declare',
-    'jimu/BaseWidget'
-], (declare, BaseWidget) => {
+import declare from 'dojo/_base/declare';
+import BaseWidget from 'jimu/BaseWidget';
+
     //To create a widget, you need to derive from BaseWidget.
-    return declare([BaseWidget], {
+    export default declare([BaseWidget], {
+
         baseClass: 'MyWidget',
         // add additional properties here
 
@@ -42,4 +42,3 @@ define([
         // }
         //methods to communication between widgets:
     });
-});


### PR DESCRIPTION
using [transform-es2015-modules-simple-amd
plugin](https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-simple-amd)
to transform es6 modules into AMD code that can be consumed by WAB modules
NOTE: transform-es2015-modules-amd won't work b/c
it always places the defined class on a `default` property and
the WAB's Dojo modules don't have the `_interopRequireDefault` function()
to know to get the property that way.

Not totally sure we want to go this route as it increases complexity, and the docs indicate that some es6 module features are unsupported.

> Other features (like import x as y from 'X' or import \* from 'X' etc) aren't supported. Just import VARIABLE from 'PATH' and import 'PATH'.
