### PR TITLE
jshint es6 settings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,6 @@
     "camelcase"     : false,    // true: Identifiers must be in camelCase
     "curly"         : true,     // true: Require {} for every new block or scope
     "eqeqeq"        : false,    // true: Require triple equals (===) for comparison ** Just use triples with undefined, null, false, 0 and 1 **
-    "es3"           : true,     // true: Adhere to ECMAScript 3 specification ** Still needed until IE8 support is dropped **
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty() ** Still needed until IE8 support is dropped **
     "immed"         : true,     // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());` ** Avoids confusion and minification errors **
     "latedef"       : false,    // true: Require variables/functions to be defined before being used
@@ -43,8 +42,7 @@
     "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
     "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
     "eqnull"        : true,      // true: Tolerate use of `== null`
-    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
-    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "esversion"     : 6,
     "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
                                  // (ex: `for each`, multiple try/catch, function expression…)
     "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`


### PR DESCRIPTION
updating jshintrc to support modern options (jshint v2.9). `es3`, `es5` and `esnext` are all deprecated, replaced by `esversion`.

Personally I had challenges with this because my editor's linting plugin was not updating the version of jshint on my machine. Had to run `npm update -g jshint`. Just a helpful tip for others that may run into this same issue.

resolves #3
